### PR TITLE
FR-1220-FR-1229: Add timer to LazyClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
 build/
 develop-eggs/
 dist/
@@ -24,6 +23,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo
@@ -53,6 +54,7 @@ coverage.xml
 # Django stuff:
 *.log
 local_settings.py
+db.sqlite3
 
 # Flask stuff:
 instance/
@@ -79,13 +81,14 @@ celerybeat-schedule
 # SageMath parsed files
 *.sage.py
 
-# dotenv
+# Environments
 .env
-
-# virtualenv
 .venv
+env/
 venv/
 ENV/
+env.bak/
+venv.bak/
 
 # Spyder project settings
 .spyderproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,22 @@
 sudo: false
 language: python
 
-python:
-  - '2.7'
-
 install:
   - pip install tox
 
-env:
-  - TOX_ENV=py27-test
-  - TOX_ENV=py33-test
-  - TOX_ENV=py34-test
+matrix:
+  include:
+    - python: 2.7
+      env: TOX_ENV=py27-test
+
+    - python: 3.4
+      env: TOX_ENV=py34-test
+
+    - python: 3.5
+      env: TOX_ENV=py35-test
+
+    - python: 3.6
+      env: TOX_ENV=py36-test
 
 script:
   - tox -e $TOX_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ Release Notes
 =============
 
 
+Version 0.0.4
+-------------
+
+Released 2018-07-25
+
+* Enable use of `timer` as context manager, respecting the `enabled` setting.
+
+
 Version 0.0.3
 -------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -2,3 +2,4 @@ Contributions have been made by:
 
 Fabrizio Romano (@gianchub)
 Julio Trigo (@juliotrigo)
+Heinrich Kruger (@heindsight)

--- a/README.rst
+++ b/README.rst
@@ -37,13 +37,19 @@ can use it within any of the service methods (entrypoints, simple methods, etc.)
             self.statsd.gauge(value)
             ...
 
+        def another_method(self, data):
+            ...
+            with self.statsd.timer('another_timer', rate=2):
+                ...
+
 
 The ``statsd.StatsClient`` instance exposes a set of methods that you can
 access without having to go through the client itself.  The dependency
 acts as a pass-through for them.  They are: ``incr``, ``decr``, ``gauge``,
-``set``, and ``timing``.
+``set``, ``timer`` and ``timing``.
 
-In the above code example, you can see how we access ``incr`` and ``gauge``.
+In the above code example, you can see how we access ``incr``, ``gauge`` and
+``timer``.
 
 You can also decorate any method in the service with the ``timer`` decorator,
 as shown in the example.  This allows you to time any method without having
@@ -158,19 +164,12 @@ is equivalent to the following:
 
         @entrypoint
         def method(...):
-            with self.statsd.client.timer('my_stat', rate=5):
+            with self.statsd.timer('my_stat', rate=5):
                 # method body
 
         def another_method(...):
-            with self.statsd.client.timer('another-stat'):
+            with self.statsd.timer('another-stat'):
                 # method body
-
-
-.. warning::
-    When using ``self.statsd.client.timer`` as a context manager, you're
-    bypassing the dependency, which means that the timer will be acted
-    regardless of how the ``enabled`` setting is configured.
-
 
 
 About the lazy client

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,3 +1,4 @@
 nameko>=2.6.0
 statsd>=3.2.1
 six>=1.10.0
+mock>=2.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 nameko>=2.6.0
 statsd>=3.2.1
 six>=1.10.0
+mock>=2.0.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,4 +1,3 @@
 coverage
 flake8
 pytest
-mock

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,3 @@
 coverage
 flake8
 pytest
-mock

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def reqs(filepath):
 
 setup(
     name='nameko-statsd',
-    version='0.0.3',
+    version='0.0.4',
     description='StatsD dependency for nameko services',
     author='Sohonet product team',
     author_email='fabrizio.romano@sohonet.com',
@@ -28,8 +28,10 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py33,py34}-test
+envlist = {py27,py34,py35,py36,py37}-test
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This adds a `timer` to the nameko-statsd `LazyClient` which will pass through to the underlying statsd client when `enabled` is `True` and returns a `MagicMock` otherwise.

I've also updated the `.gitignore` file and configured tox to test against more recent python versions.