### PR TITLE
FR-996: Add option to use TCP instead of UDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@ Release Notes
 =============
 
 
+Version 0.0.5
+-------------
+
+Release Pending
+
+* Enable use of TCP instead of UDP.
+
 Version 0.0.4
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Release Notes
 Version 0.0.5
 -------------
 
-Release Pending
+Released 2018-08-10
 
 * Enable use of TCP instead of UDP.
 

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,5 @@ flake8:
 	flake8 nameko_statsd test
 
 pytest:
-	coverage run --concurrency=eventlet --source nameko_statsd --branch -m pytest test
+	coverage run --concurrency=eventlet --source nameko_statsd --branch -m pytest $(ARGS) test
 	coverage report --show-missing --fail-under=100

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ nameko-statsd
 .. image:: https://travis-ci.org/sohonetlabs/nameko-statsd.svg?branch=master
 
 A StatsD dependency for `nameko <http://nameko.readthedocs.org>`_, enabling
-services to send stats.
+services to send stats using `pystatsd <http://statsd.readthedocs.org>`_.
 
 
 
@@ -60,33 +60,38 @@ to change its logic.
 Configuration
 -------------
 
-The library expects the following values to be in the config file you
-use for your service (you need one configuration block per different
-statsd server).  For example, if we had two statsd servers, prod1 and
-prod2, we would have something like this:
+The library accepts any arguments accepted by ``statsd.StatsClient`` or
+``statsd.TCPStatsClient`` in the service configuration file as well as two
+additional items that control the behaviour of the dependency itself
+(``enabled`` and ``protocol``). You need one configuration block per different
+statsd server.  For example, if we had two statsd servers, prod1 and
+prod2, we could have something like this:
 
 .. code-block:: yaml
 
     STATSD:
       prod1:
+        enabled: true
+        protocol: "udp"
         host: "host1"
         port: 8125
         prefix: "prefix-1"
         maxudpsize: 512
-        enabled: true
       prod2:
+        enabled: false
+        protocol: "tcp"
         host: "host2"
         port: 8125
         prefix: "prefix-2"
-        maxudpsize: 512
-        enabled: false
 
 
-The first four values are passed directly to ``statsd.StatsClient`` on
-creation.  The last one, ``enabled``, will activate/deactivate all stats,
-according to how it is set (``true``/``false``).  In this example,
-production 1 is enabled while production 2 is not.
-
+The ``enabled`` value will activate/deactivate all stats, according to how it
+is set (``true``/``false``).  In this example, production 1 is enabled while
+production 2 is not. You can set ``protocol`` to ``tcp`` (case insensitive) to
+use the TCP based ``statsd.TCPStatsClient``, if ``protocol`` is omitted (or set
+to ``udp``) the default UDP based ``statsd.StatsClient`` will be used. All
+remaining values are passed directly to ``statsd.StatsClient`` (or
+``statsd.TCPStatsClient``) on creation.
 
 
 Minimum setup

--- a/nameko_statsd/statsd_dep.py
+++ b/nameko_statsd/statsd_dep.py
@@ -1,8 +1,14 @@
+from enum import Enum
 from functools import wraps, partial
 from mock import MagicMock
 
 from nameko.extensions import DependencyProvider
-from statsd import StatsClient
+from statsd import StatsClient, TCPStatsClient
+
+
+class Protocols(Enum):
+    tcp = 'tcp'
+    udp = 'udp'
 
 
 class LazyClient(object):
@@ -11,19 +17,27 @@ class LazyClient(object):
     """
 
     def __init__(self, **config):
-        self.config = dict(
-            host=config['host'],
-            port=config['port'],
-            prefix=config['prefix'],
-            maxudpsize=config['maxudpsize'],
-        )
-        self.enabled = config['enabled']
+        self.config = config
+        self.enabled = config.pop('enabled')
         self._client = None
+
+        protocol = self.config.pop('protocol', Protocols.udp.name)
+
+        try:
+            self.protocol = getattr(Protocols, protocol.lower())
+        except AttributeError:
+            raise ValueError(
+                'Invalid protocol: {}'.format(protocol)
+            )
 
     @property
     def client(self):
         if self._client is None:
-            self._client = StatsClient(**self.config)
+            if self.protocol is Protocols.udp:
+                self._client = StatsClient(**self.config)
+            else:   # self.protocol is Protocols.tcp
+                self._client = TCPStatsClient(**self.config)
+
         return self._client
 
     def __getattr__(self, name):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,3 +2,4 @@ nameko>=2.6.0
 statsd>=3.2.1
 six>=1.10.0
 mock>=2.0.0
+enum34>=1.1.6

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,3 +2,4 @@ nameko>=2.6.0
 statsd>=3.2.1
 six>=1.10.0
 mock>=2.0.0
+enum34>=1.1.6

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def reqs(filepath):
 
 setup(
     name='nameko-statsd',
-    version='0.0.4',
+    version='0.0.5',
     description='StatsD dependency for nameko services',
     author='Sohonet product team',
     author_email='fabrizio.romano@sohonet.com',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -19,5 +19,21 @@ def stats_config():
                 'maxudpsize': 128,
                 'enabled': False,
             },
+            'test-tcp': {
+                'host': 'tcp.statsd.host',
+                'port': 4321,
+                'prefix': 'tcp.statsd.prefix',
+                'timeout': 5,
+                'enabled': True,
+                'protocol': 'tcp',
+            },
+            'test-tcp-disabled': {
+                'host': 'tcp.statsd.host.disabled',
+                'port': 5432,
+                'prefix': 'tcp.statsd.prefix.disabled',
+                'timeout': 10,
+                'enabled': False,
+                'protocol': 'tcp',
+            },
         }
     }

--- a/test/test_lazy_client.py
+++ b/test/test_lazy_client.py
@@ -1,23 +1,31 @@
 from mock import Mock, call, patch
 import pytest
 
-from nameko_statsd.statsd_dep import LazyClient
+from nameko_statsd.statsd_dep import LazyClient, Protocols
 
 
 class TestLazyClient(object):
 
     """Test the `LazyClient` class features. """
 
-    @pytest.fixture
-    def stats_config(self, stats_config):
-        return stats_config['STATSD']['test'].copy()
-
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def stats_client_cls(self):
         with patch('nameko_statsd.statsd_dep.StatsClient') as sc:
             yield sc
 
-    def test_init(self, stats_client_cls, stats_config):
+    @pytest.fixture(autouse=True)
+    def stats_client_cls_tcp(self):
+        with patch('nameko_statsd.statsd_dep.TCPStatsClient') as sc:
+            yield sc
+
+
+class TestLazyClientUDP(TestLazyClient):
+
+    @pytest.fixture
+    def stats_config(self, stats_config):
+        return stats_config['STATSD']['test'].copy()
+
+    def test_init(self, stats_client_cls, stats_client_cls_tcp, stats_config):
         lc = LazyClient(**stats_config)
 
         assert lc.config == dict(
@@ -29,11 +37,25 @@ class TestLazyClient(object):
         assert lc.enabled
         assert lc._client is None
         assert stats_client_cls.call_count == 0
+        assert stats_client_cls_tcp.call_count == 0
 
-    def test_client(self, stats_client_cls, stats_config):
+    @pytest.mark.parametrize('proto', ('UPD', 'upd', 'IP', 'TPC', 'tPc'))
+    def test_init_invalid_protocol(
+        self, stats_client_cls, stats_client_cls_tcp, stats_config, proto
+    ):
+        with pytest.raises(ValueError) as err:
+            LazyClient(protocol=proto, **stats_config)
+
+        assert err.match('Invalid protocol')
+
+    def test_client_default_protocol(
+        self, stats_client_cls, stats_client_cls_tcp, stats_config
+    ):
         lc = LazyClient(**stats_config)
 
         client = lc.client  # this is a property
+
+        assert lc.protocol is Protocols.udp
 
         assert stats_client_cls.call_args_list == [
             call(
@@ -44,11 +66,85 @@ class TestLazyClient(object):
             )
         ]
         assert client == stats_client_cls.return_value
+        assert stats_client_cls_tcp.call_count == 0
+
+    @pytest.mark.parametrize('proto', ('udp', 'UDP', 'UdP', 'uDp'))
+    def test_client_udp(
+        self, stats_client_cls, stats_client_cls_tcp, stats_config, proto
+    ):
+        lc = LazyClient(protocol=proto, **stats_config)
+
+        client = lc.client  # this is a property
+
+        assert lc.protocol is Protocols.udp
+
+        assert stats_client_cls.call_args_list == [
+            call(
+                host='statsd.host',
+                port=1234,
+                prefix='statsd.prefix',
+                maxudpsize=1024,
+            )
+        ]
+        assert client == stats_client_cls.return_value
+        assert stats_client_cls_tcp.call_count == 0
+
+
+class TestLazyClientTCP(TestLazyClient):
+
+    @pytest.fixture
+    def stats_config(self, stats_config):
+        return stats_config['STATSD']['test-tcp'].copy()
+
+    def test_init(
+        self, stats_client_cls, stats_client_cls_tcp, stats_config
+    ):
+        lc = LazyClient(**stats_config)
+
+        assert lc.config == dict(
+            host='tcp.statsd.host',
+            port=4321,
+            prefix='tcp.statsd.prefix',
+            timeout=5,
+        )
+        assert lc.enabled
+        assert lc._client is None
+        assert stats_client_cls.call_count == 0
+        assert stats_client_cls_tcp.call_count == 0
+
+    @pytest.mark.parametrize('proto', ('tcp', 'TCP', 'TcP', 'tCp'))
+    def test_client(
+        self, stats_client_cls, stats_client_cls_tcp, stats_config, proto
+    ):
+        del stats_config['protocol']
+        lc = LazyClient(protocol=proto, **stats_config)
+
+        client = lc.client  # this is a property
+
+        assert lc.protocol is Protocols.tcp
+
+        assert stats_client_cls_tcp.call_args_list == [
+            call(
+                host='tcp.statsd.host',
+                port=4321,
+                prefix='tcp.statsd.prefix',
+                timeout=5,
+            )
+        ]
+        assert client == stats_client_cls_tcp.return_value
+        assert stats_client_cls.call_count == 0
+
+
+class TestStatMethods(TestLazyClient):
+
+    @pytest.fixture(params=['test', 'test-tcp'])
+    def stats_config(self, request, stats_config):
+        return stats_config['STATSD'][request.param].copy()
 
     @pytest.mark.parametrize('method', [
         'incr', 'decr', 'gauge', 'set', 'timing'
     ])
-    def test_passthrough_methods(self, method, stats_client_cls, stats_config):
+    def test_passthrough_methods(self, method, stats_config):
         lc = LazyClient(**stats_config)
 
         delegate = getattr(lc, method)
@@ -65,7 +161,7 @@ class TestLazyClient(object):
         'incr', 'decr', 'gauge', 'set', 'timing'
     ])
     def test_passthrough_disabled(
-        self, method, stats_client_cls, stats_config
+        self, method, stats_config
     ):
         stats_config['enabled'] = False
         lc = LazyClient(**stats_config)
@@ -77,7 +173,7 @@ class TestLazyClient(object):
 
         assert getattr(lc.client, method).call_args_list == []
 
-    def test_getattr(self, stats_client_cls, stats_config):
+    def test_getattr(self, stats_config):
         lc = LazyClient(**stats_config)
 
         with pytest.raises(AttributeError) as exc_info:


### PR DESCRIPTION
This adds a `protocol` config to the statsd dependency which can be used to choose between the TCP based `statsd.TCPStatsdClient` and the UDP based `statsd.StatsClient`.