### PR TITLE
ServiceBaseMeta should not change the class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@ Release Notes
 =============
 
 
+Version 0.0.6
+-------------
+
+Release Pending
+
+* Fix a bug in the `ServiceBaseMeta` metaclass which caused classes to have the
+  wrong name.
+
+
 Version 0.0.5
 -------------
 

--- a/nameko_statsd/bases.py
+++ b/nameko_statsd/bases.py
@@ -11,9 +11,9 @@ class ServiceBaseMeta(type):
 
     def __new__(cls, name, bases, attrs):
 
-        for name, obj in attrs.items():
+        for attr_name, obj in attrs.items():
             if isinstance(obj, StatsD):
-                obj._name = name
+                obj._name = attr_name
 
         return type.__new__(cls, name, bases, attrs)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def reqs(filepath):
 
 setup(
     name='nameko-statsd',
-    version='0.0.5',
+    version='0.0.6',
     description='StatsD dependency for nameko services',
     author='Sohonet product team',
     author_email='fabrizio.romano@sohonet.com',

--- a/test/test_bases.py
+++ b/test/test_bases.py
@@ -1,0 +1,14 @@
+from six import add_metaclass
+
+from nameko_statsd.bases import ServiceBaseMeta
+
+
+def test_metaclass():
+
+    @add_metaclass(ServiceBaseMeta)
+    class DummyService(object):
+
+        def some_method(self):
+            pass
+
+    assert DummyService.__name__ == 'DummyService'


### PR DESCRIPTION
This fixes a bug where the `ServiceBaseMeta` metaclass was redefining the `name` argument and thus passing the wrong class name to `type.__new__`.