### PR TITLE
Add Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: python
 python: 3.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,34 @@
 sudo: false
+
 language: python
+python: 3.7
+
+dist: xenial
 
 install:
   - pip install tox
 
 matrix:
   include:
-    - python: 2.7
-      env: TOX_ENV=py27-test
+    - stage: test
+      python: 2.7
+      env: TOX_ENV=py27
 
-    - python: 3.4
-      env: TOX_ENV=py34-test
+    - stage: test
+      python: 3.4
+      env: TOX_ENV=py34
 
-    - python: 3.5
-      env: TOX_ENV=py35-test
+    - stage: test
+      python: 3.5
+      env: TOX_ENV=py35
 
-    - python: 3.6
-      env: TOX_ENV=py36-test
+    - stage: test
+      python: 3.6
+      env: TOX_ENV=py36
+
+    - stage: test
+      python: 3.7
+      env: TOX_ENV=py36
 
 script:
   - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,23 @@ matrix:
   include:
     - stage: test
       python: 2.7
-      env: TOX_ENV=py27
+      env: TOX_ENV="py27-nameko{2.11,2.12,latest}"
 
     - stage: test
       python: 3.4
-      env: TOX_ENV=py34
+      env: TOX_ENV="py34-nameko{2.11,2.12,latest}"
 
     - stage: test
       python: 3.5
-      env: TOX_ENV=py35
+      env: TOX_ENV="py35-nameko{2.11,2.12,latest}"
 
     - stage: test
       python: 3.6
-      env: TOX_ENV=py36
+      env: TOX_ENV="py36-nameko{2.11,2.12,latest}"
 
     - stage: test
       python: 3.7
-      env: TOX_ENV=py37
+      env: TOX_ENV="py37-nameko{2.11,2.12,latest}"
 
 script:
   - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
 
     - stage: test
       python: 3.7
-      env: TOX_ENV=py36
+      env: TOX_ENV=py37
 
 script:
   - tox -e $TOX_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 Release Notes
 =============
 
+Here you can see the full list of changes between
+nameko-statsd versions, where semantic versioning is used:
+*major.minor.patch*.
+
+Backwards-compatible changes increment the minor version number only.
+
+
+Version 0.1.0
+-------------
+
+Release Pending
+
+* Add support for Python 3.7 (#10)
+* Add Nameko ``2.11`` and ``2.12`` support (#10)
+* Switch to semantic versioning (#10)
+
 
 Version 0.0.6
 -------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,9 @@
 include requirements/base.txt
 include requirements/dev.txt
+include CHANGELOG.md
+include CONTRIBUTORS.txt
+include LICENSE
+include README.rst
+
+global-exclude __pycache__
+global-exclude *.pyc

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ rst-lint:
 	rst-lint README.rst
 
 flake8:
-	flake8 $(PACKAGE_NAME) test
+	flake8 $(PACKAGE_NAME) test setup.py
 
 pytest:
 	coverage run --concurrency=eventlet --source $(PACKAGE_NAME) --branch \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
-test: flake8 pytest
+.PHONY: test
+
+
+PACKAGE_NAME=nameko_statsd
+
+
+test: rst-lint flake8 pytest
+
+rst-lint:
+	rst-lint README.rst
 
 flake8:
-	flake8 nameko_statsd test
+	flake8 $(PACKAGE_NAME) test
 
 pytest:
-	coverage run --concurrency=eventlet --source nameko_statsd --branch -m pytest $(ARGS) test
+	coverage run --concurrency=eventlet --source $(PACKAGE_NAME) --branch \
+		-m pytest $(ARGS) test
 	coverage report --show-missing --fail-under=100

--- a/README.rst
+++ b/README.rst
@@ -199,3 +199,9 @@ a client is created.
 This lazy feature means you can attach as many ``nameko_statsd.StatsD``
 dependencies to your service as you fancy, and no client will be created
 unless it is actually used.
+
+
+Nameko support
+--------------
+
+The following Nameko versions are supported: ``2.11``, ``2.12``.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,17 @@
-nameko-statsd
+Nameko StatsD
 =============
 
+.. image:: https://img.shields.io/pypi/v/nameko-statsd.svg
+    :target: https://pypi.org/project/nameko-statsd/
+
+.. image:: https://img.shields.io/pypi/pyversions/nameko-statsd.svg
+    :target: https://pypi.org/project/nameko-statsd/
+
+.. image:: https://img.shields.io/pypi/format/nameko-statsd.svg
+    :target: https://pypi.org/project/nameko-statsd/
+
 .. image:: https://travis-ci.org/sohonetlabs/nameko-statsd.svg?branch=master
+    :target: https://travis-ci.org/sohonetlabs/nameko-statsd
 
 A StatsD dependency for `nameko <http://nameko.readthedocs.org>`_, enabling
 services to send stats using `pystatsd <http://statsd.readthedocs.org>`_.
@@ -12,7 +22,8 @@ Usage
 -----
 
 To use the dependency you simply declare it on the service and then you
-can use it within any of the service methods (entrypoints, simple methods, etc.).
+can use it within any of the service methods (entrypoints, simple methods,
+etc.).
 
 
 .. code-block:: python

--- a/nameko_statsd/bases.py
+++ b/nameko_statsd/bases.py
@@ -21,3 +21,4 @@ class ServiceBaseMeta(type):
 @add_metaclass(ServiceBaseMeta)
 class ServiceBase(object):
     """Service base class. """
+    pass

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,5 @@
 coverage
 flake8
 pytest
+restructuredtext-lint
+Pygments

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,5 @@
 coverage
 flake8
 pytest
+restructuredtext-lint
+Pygments

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'dev': reqs('requirements/dev.txt'),
     },
     zip_safe=True,
-    license='MIT',
+    license='MIT License',
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     version='0.0.6',
     description=description,
     long_description=description,
+    long_description_content_type='text/x-rst',
     author='Sohonet product team',
     author_email='fabrizio.romano@sohonet.com',
     url='https://github.com/sohonetlabs/nameko-statsd',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ description = 'StatsD dependency for nameko services.'
 
 setup(
     name='nameko-statsd',
-    version='0.0.6',
+    version='0.1.0',
     description=description,
     long_description=description,
     long_description_content_type='text/x-rst',

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,11 @@ setup(
     zip_safe=True,
     license='MIT',
     classifiers=[
-        "Programming Language :: Python",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX",
+        "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
@@ -38,6 +40,5 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        "Intended Audience :: Developers",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27, py34, py35, py36, py37}
+envlist = {py27,py34,py35,py36,py37}
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,13 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37}
+envlist = {py27,py34,py35,py36,py37}-nameko{2.11,2.12,latest}
 skipsdist = True
 
 [testenv]
 whitelist_externals = make
 usedevelop = true
 extras = dev
+deps =
+    nameko2.11: nameko>=2.11,<2.12
+    nameko2.12: nameko>=2.12,<2.13
 commands =
     make test

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37}-test
+envlist = {py27, py34, py35, py36, py37}
 skipsdist = True
 
 [testenv]
 whitelist_externals = make
-
+usedevelop = true
+extras = dev
 commands =
-    pip install --editable .[dev]
     make test


### PR DESCRIPTION
* New versions & release notes
* Add. Python 3.7 support:
  * Test the library with Python 3.7 on Travis
  * Travis now uses Python 3.7
  * Fix branch coverage, related to an empty class
* Add Nameko `2.12` support
* Make sure the latest Nameko release is tested without the need to explicitly add it
* Improve CI logic:
  * Make better use of Tox attributes for `develop` mode and extra packages
  * Use `xenial` Ubuntu distribution with Travis.
  * `sudo` Travis keyword has been fully deprecated.
  * Add the `test` `stage` to Travis
  * Include the `setup.py` module in the `flake8` checks
* Add ReStructuredText linter
* Refactor Makefile
* Improve README documentation
* Improve PyPI classifiers
* Amend `license` `setup` attribute
* Improve `MANIFEST.in` file