### PR TITLE
Remove need for custom metaclass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,19 @@ matrix:
   include:
     - stage: test
       python: 2.7
-      env: TOX_ENV="py27-nameko{2.11,2.12,latest}"
-
-    - stage: test
-      python: 3.4
-      env: TOX_ENV="py34-nameko{2.11,2.12,latest}"
+      env: TOX_ENV="py27-nameko{2.9,2.10,2.11,2.12,latest}"
 
     - stage: test
       python: 3.5
-      env: TOX_ENV="py35-nameko{2.11,2.12,latest}"
+      env: TOX_ENV="py35-nameko{2.6,2.7,2.8,2.9,2.10,2.11,2.12,latest}"
 
     - stage: test
       python: 3.6
-      env: TOX_ENV="py36-nameko{2.11,2.12,latest}"
+      env: TOX_ENV="py36-nameko{2.6,2.7,2.8,2.9,2.10,2.11,2.12,latest}"
 
     - stage: test
       python: 3.7
-      env: TOX_ENV="py37-nameko{2.11,2.12,latest}"
+      env: TOX_ENV="py37-nameko{2.6,2.7,2.8,2.9,2.10,2.11,2.12,latest}"
 
 script:
   - tox -e $TOX_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ nameko-statsd versions, where semantic versioning is used:
 Backwards-compatible changes increment the minor version number only.
 
 
+Version 0.1.1
+-------------
+
+* Deprecate the `ServiceBaseMeta` metaclass and the `name` argument to the
+  `StatsD` dependency provider.
+* Test on older Nameko versions and against pre-release versions of
+  dependencies.
+
 Version 0.1.0
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -28,9 +28,9 @@ etc.).
 
 .. code-block:: python
 
-    from nameko_statsd import StatsD, ServiceBase
+    from nameko_statsd import StatsD
 
-    class Service(ServiceBase):
+    class Service:
 
         statsd = StatsD('prod1')
 
@@ -105,48 +105,6 @@ remaining values are passed directly to ``statsd.StatsClient`` (or
 ``statsd.TCPStatsClient``) on creation.
 
 
-Minimum setup
--------------
-
-At the time of writing a Nameko service, you don't have access to the
-config values.  This means that when we write our service we don't have
-access to the actual dependencies (they are injected later).
-
-In order to give the users of this library the ability to decorate
-methods with the ``timer`` decorator, we need to do a little wiring
-behind the scenes.  The only thing required for the end user is to write
-the service class so that it inherits from ``nameko_statsd.ServiceBase``.
-
-The *type* of ``nameko_statsd.ServiceBase`` is a custom metaclass that
-provides the necessary wirings to any ``nameko_statsd.StatsD`` dependency.
-
-If you cannot inherit from ``nameko_statsd.ServiceBase`` for any reason,
-all you have to do is to make sure you pass a ``name`` argument to any
-``nameko_statsd.StatsD`` dependency, the value of which has to match the
-attribute name of the dependency itself.
-
-The following configuration:
-
-.. code-block:: python
-
-    class MyService(ServiceBase):
-
-        statsd = StatsD('prod1')
-
-        ...
-
-is equivalent to (notice it inherits from ``object``):
-
-.. code-block:: python
-
-    class MyService(object):
-
-        statsd = StatsD('prod1', name='statsd')
-
-        ...
-
-
-
 The ``StatsD.timer`` decorator
 ------------------------------
 
@@ -157,7 +115,7 @@ So, for example:
 
 .. code-block:: python
 
-    class MyService(ServiceBase):
+    class MyService:
 
         statsd = StatsD('prod1')
 
@@ -174,7 +132,7 @@ is equivalent to the following:
 
 .. code-block:: python
 
-    class MyService(ServiceBase):
+    class MyService:
 
         statsd = StatsD('prod1')
 
@@ -205,3 +163,19 @@ Nameko support
 --------------
 
 The following Nameko versions are supported: ``2.11``, ``2.12``.
+
+
+Deprecation of the ``ServiceBase`` base class and ``name`` argument
+-------------------------------------------------------------------
+
+In previous versions of ``nameko-statsd``, the ``timer`` decorator could only
+be used if the service class inherited from  ``nameko_statsd.ServiceBase`` or
+if the correct ``name`` argument was passed to the ``nameko_statsd.StatsD``
+dependency provider.
+
+Since version ``0.1.1``, ``nameko_statsd.StatsD`` is able
+to determine the correct attribute name when ``nameko`` binds the dependency
+provider to the service. Therefore, ``name`` argument to the
+``nameko_statsd.StatsD`` dependency provider, the ``nameko_statsd.ServiceBase``
+base class (and the associated metaclass) have been deprecated and will be
+removed in a future release.

--- a/nameko_statsd/bases.py
+++ b/nameko_statsd/bases.py
@@ -1,6 +1,6 @@
-from six import add_metaclass
+from warnings import warn
 
-from .statsd_dep import StatsD
+from six import add_metaclass
 
 
 class ServiceBaseMeta(type):
@@ -10,10 +10,12 @@ class ServiceBaseMeta(type):
     """
 
     def __new__(cls, name, bases, attrs):
-
-        for attr_name, obj in attrs.items():
-            if isinstance(obj, StatsD):
-                obj._name = attr_name
+        warn(
+            "Use of the `ServiceBaseMeta` metaclass is no longer needed."
+            " `ServiceBaseMeta` is deprecated and will be removed in a future"
+            " release of `nameko-statsd`.",
+            DeprecationWarning
+        )
 
         return type.__new__(cls, name, bases, attrs)
 

--- a/nameko_statsd/statsd_dep.py
+++ b/nameko_statsd/statsd_dep.py
@@ -88,7 +88,7 @@ class StatsD(DependencyProvider):
 
             @wraps(method)
             def wrapper(svc, *args, **kwargs):
-                dependency = getattr(svc, self._name)
+                dependency = getattr(svc, self.attr_name)
 
                 if dependency.enabled:
                     with dependency.client.timer(*targs, **tkwargs):

--- a/nameko_statsd/statsd_dep.py
+++ b/nameko_statsd/statsd_dep.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from functools import wraps, partial
 from mock import MagicMock
+from warnings import warn
 
 from nameko.extensions import DependencyProvider
 from statsd import StatsClient, TCPStatsClient
@@ -69,7 +70,14 @@ class StatsD(DependencyProvider):
             name (str): The name associated to the instance.
         """
         self._key = key
-        self._name = name or ''
+
+        if name is not None:
+            warn(
+                "The `name` argument to `StatsD` is no longer needed and has"
+                " been deprecated.",
+                DeprecationWarning
+            )
+
         super(StatsD, self).__init__(*args, **kwargs)
 
     def get_dependency(self, worker_ctx):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ description = 'StatsD dependency for nameko services.'
 
 setup(
     name='nameko-statsd',
-    version='0.1.0',
+    version='0.1.1',
     description=description,
     long_description=description,
     long_description_content_type='text/x-rst',
@@ -35,7 +35,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/test/test_bases.py
+++ b/test/test_bases.py
@@ -1,3 +1,5 @@
+import warnings
+
 from six import add_metaclass
 
 from nameko_statsd.bases import ServiceBaseMeta
@@ -12,3 +14,17 @@ def test_metaclass():
             pass
 
     assert DummyService.__name__ == 'DummyService'
+
+
+def test_metaclass_deprecated(recwarn):
+    warnings.simplefilter("always")
+
+    ServiceBaseMeta('DummyService', (object,), {})
+
+    assert len(recwarn) == 1
+    warn = recwarn.pop()
+    assert str(warn.message) == (
+        "Use of the `ServiceBaseMeta` metaclass is no longer needed."
+        " `ServiceBaseMeta` is deprecated and will be removed in a future"
+        " release of `nameko-statsd`."
+    )

--- a/test/test_nameko_statsd.py
+++ b/test/test_nameko_statsd.py
@@ -1,3 +1,5 @@
+import warnings
+
 from mock import call, Mock, patch
 import pytest
 from nameko.testing.services import dummy, entrypoint_hook
@@ -57,6 +59,17 @@ class TestStatsD(object):
             )
         ]
         assert dep == lazy_client_cls.return_value
+
+    def test_name_argument_deprecated(self, recwarn):
+        warnings.simplefilter("always")
+        StatsD('test', name='statsd')
+
+        assert len(recwarn) == 1
+        warn = recwarn.pop()
+        assert str(warn.message) == (
+            "The `name` argument to `StatsD` is no longer needed and has been"
+            " deprecated."
+        )
 
 
 class DummyService(object):

--- a/test/test_nameko_statsd.py
+++ b/test/test_nameko_statsd.py
@@ -164,7 +164,7 @@ class DummyServiceMeta(ServiceBase):
 
     name = 'dummy_service'
 
-    statsd = StatsD('test', name='statsd')
+    statsd = StatsD('test')
 
     @dummy
     @statsd.timer('nice-stat', rate=3)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37}-nameko{2.11,2.12,latest}
+envlist =
+    py27-nameko{2.9, 2.10, 2.11, 2.12, latest},
+    {py35, py36, py37}-nameko{2.6, 2.7, 2.8, 2.9, 2.10, 2.11, 2.12, latest, next}
+
 skipsdist = True
 
 [testenv]
@@ -7,7 +10,18 @@ whitelist_externals = make
 usedevelop = true
 extras = dev
 deps =
-    nameko2.11: nameko>=2.11,<2.12
-    nameko2.12: nameko>=2.12,<2.13
+    nameko{2.6,2.7}: pytest<3.3.0
+    nameko{2.6,2.7,2.8}: eventlet<0.22.0
+    nameko2.6: nameko~=2.6
+    nameko2.7: nameko~=2.7
+    nameko2.8: nameko~=2.8
+    nameko2.9: nameko~=2.9
+    nameko2.10: nameko~=2.10
+    nameko2.11: nameko~=2.11
+    nameko2.12: nameko~=2.12
+
 commands =
     make test
+
+pip_pre =
+    namekonext: true


### PR DESCRIPTION
The `nameko.extensions.DependencyProvider.bind` method sets the `attr_name` attribute of the dependency provider to the attribute name of the service class that it is bound to. The `nameko_statsd.StatsD.timer` decorator can use this instead of requiring the name to be passed as a parameter to the dependency provider (or set it via a metaclass on the service class).