### PR TITLE
Add support for pipeline when disabled etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,15 @@ matrix:
 
     - stage: test
       python: 3.5
-      env: TOX_ENV="py35-nameko{2.6,2.7,2.8,2.9,2.10,2.11,2.12,latest}"
+      env: TOX_ENV="py35-nameko{2.7,2.8,2.9,2.10,2.11,2.12,latest}"
 
     - stage: test
       python: 3.6
-      env: TOX_ENV="py36-nameko{2.6,2.7,2.8,2.9,2.10,2.11,2.12,latest}"
+      env: TOX_ENV="py36-nameko{2.7,2.8,2.9,2.10,2.11,2.12,latest}"
 
     - stage: test
       python: 3.7
-      env: TOX_ENV="py37-nameko{2.6,2.7,2.8,2.9,2.10,2.11,2.12,latest}"
+      env: TOX_ENV="py37-nameko{2.7,2.8,2.9,2.10,2.11,2.12,latest}"
 
 script:
   - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,9 @@ matrix:
       python: 3.7
       env: TOX_ENV="py37-nameko{2.7,2.8,2.9,2.10,2.11,2.12,latest}"
 
+    - stage: test
+      python: 3.8-dev
+      env: TOX_ENV="py38-nameko{2.7,2.8,2.9,2.10,2.11,2.12,latest}"
+
 script:
   - tox -e $TOX_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Version 0.1.1
 * Deprecate the `ServiceBaseMeta` metaclass and the `name` argument to the
   `StatsD` dependency provider.
 * Add support for pipeline when disabled
-* Test on older Nameko versions and against pre-release versions of
+* Test on older Nameko versions (back to 2.7) and against pre-release versions of
   dependencies.
 * Test on Python 3.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ Version 0.1.1
 
 * Deprecate the `ServiceBaseMeta` metaclass and the `name` argument to the
   `StatsD` dependency provider.
+* Add support for pipeline when disabled
 * Test on older Nameko versions and against pre-release versions of
   dependencies.
+* Test on Python 3.8
 
 Version 0.1.0
 -------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,3 +3,4 @@ Contributions have been made by:
 Fabrizio Romano (@gianchub)
 Julio Trigo (@juliotrigo)
 Heinrich Kruger (@heindsight)
+Tom Viner (@tomviner)

--- a/nameko_statsd/statsd_dep.py
+++ b/nameko_statsd/statsd_dep.py
@@ -97,7 +97,43 @@ class StatsD(DependencyProvider):
         return self.container.config['STATSD'][self._key]
 
     def timer(self, *targs, **tkwargs):
+        """Decorate a nameko service method.
 
+        It can be applied to any instance method in a nameko service class,
+        even to RPC or HTTP entrypoints.  If `dependency.enabled` is `False`
+        this decorator is equivalent to a no-op.
+
+        Args:
+            *targs: Positional arguments to be given to `StatsClient.timer()`.
+            *tkwargs: Keyword arguments to be given to `StatsClient.timer()`.
+
+        Decorating a service like this:
+
+        .. code-block:: python
+
+            class MyService:
+
+                statsd = StatsD('config_key')
+
+                @rpc (or @http or even nothing)
+                @statsd.timer('my_stat', rate=5)
+                def method(...):
+                    # method body
+
+        is equivalent to the following:
+
+        .. code-block:: python
+
+            class MyService:
+
+                statsd = StatsD('config_key')
+
+                @rpc (or @http or even nothing)
+                def method(...):
+                    with self.statsd.client.timer('my_stat', rate=5):
+                        # method body
+
+        """
         def decorator(method):
 
             @wraps(method)

--- a/nameko_statsd/statsd_dep.py
+++ b/nameko_statsd/statsd_dep.py
@@ -60,6 +60,12 @@ class LazyClient(object):
         else:
             return MagicMock()
 
+    def pipeline(self, *args, **kwargs):
+        if self.enabled:
+            return self.client.pipeline(*args, **kwargs)
+        else:
+            return MagicMock()
+
 
 class StatsD(DependencyProvider):
 

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,7 @@
 coverage
 flake8
+# Restricted until eventlet works with Pytest 5
+# https://github.com/pytest-dev/pytest/issues/5725
 pytest<5.0.0
 restructuredtext-lint
 Pygments

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,5 @@
 coverage
 flake8
-pytest
+pytest<5.0.0
 restructuredtext-lint
 Pygments

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 coverage
 flake8
-pytest
+pytest<5.0.0
 restructuredtext-lint
 Pygments

--- a/test/test_lazy_client.py
+++ b/test/test_lazy_client.py
@@ -208,14 +208,14 @@ class TestStatMethods(TestLazyClient):
 
     def test_pipeline_contextmanager_enabled(
             self, stats_client_cls, stats_config
-        ):
+    ):
         lc = LazyClient(**stats_config)
 
-        with lc.pipeline() as pipeline:
-            pipeline.incr('foo')
-            pipeline.send()
+        with lc.pipeline() as pipe:
+            pipe.incr('foo')
+            pipe.send()
 
-        assert pipeline is lc.client.pipeline.return_value.__enter__.return_value
+        assert pipe is lc.client.pipeline.return_value.__enter__.return_value
         assert lc.client.pipeline.call_args_list == [call()]
         assert lc.client.pipeline.mock_calls == [
             call(),
@@ -231,10 +231,10 @@ class TestStatMethods(TestLazyClient):
         stats_config['enabled'] = False
         lc = LazyClient(**stats_config)
 
-        with lc.pipeline() as pipeline:
-            pipeline.incr('foo')
-            pipeline.send()
+        with lc.pipeline() as pipe:
+            pipe.incr('foo')
+            pipe.send()
 
-        assert isinstance(pipeline, Mock)
+        assert isinstance(pipe, Mock)
         assert lc.client.pipeline.call_args_list == []
         assert lc.client.pipeline.mock_calls == []

--- a/test/test_lazy_client.py
+++ b/test/test_lazy_client.py
@@ -158,7 +158,7 @@ class TestStatMethods(TestLazyClient):
         ]
 
     @pytest.mark.parametrize('method', [
-        'incr', 'decr', 'gauge', 'set', 'timing', 'pipeline',
+        'incr', 'decr', 'gauge', 'set', 'timing', 'timer', 'pipeline',
     ])
     def test_passthrough_disabled(
         self, method, stats_config

--- a/test/test_lazy_client.py
+++ b/test/test_lazy_client.py
@@ -216,7 +216,6 @@ class TestStatMethods(TestLazyClient):
             pipe.send()
 
         assert pipe is lc.client.pipeline.return_value.__enter__.return_value
-        assert lc.client.pipeline.call_args_list == [call()]
         assert lc.client.pipeline.mock_calls == [
             call(),
             call().__enter__(),
@@ -236,5 +235,4 @@ class TestStatMethods(TestLazyClient):
             pipe.send()
 
         assert isinstance(pipe, Mock)
-        assert lc.client.pipeline.call_args_list == []
         assert lc.client.pipeline.mock_calls == []

--- a/test/test_lazy_client.py
+++ b/test/test_lazy_client.py
@@ -142,7 +142,7 @@ class TestStatMethods(TestLazyClient):
         return stats_config['STATSD'][request.param].copy()
 
     @pytest.mark.parametrize('method', [
-        'incr', 'decr', 'gauge', 'set', 'timing'
+        'incr', 'decr', 'gauge', 'set', 'timing', 'pipeline',
     ])
     def test_passthrough_methods(self, method, stats_config):
         lc = LazyClient(**stats_config)
@@ -158,7 +158,7 @@ class TestStatMethods(TestLazyClient):
         ]
 
     @pytest.mark.parametrize('method', [
-        'incr', 'decr', 'gauge', 'set', 'timing'
+        'incr', 'decr', 'gauge', 'set', 'timing', 'pipeline',
     ])
     def test_passthrough_disabled(
         self, method, stats_config

--- a/test/test_lazy_client.py
+++ b/test/test_lazy_client.py
@@ -142,7 +142,7 @@ class TestStatMethods(TestLazyClient):
         return stats_config['STATSD'][request.param].copy()
 
     @pytest.mark.parametrize('method', [
-        'incr', 'decr', 'gauge', 'set', 'timing', 'pipeline',
+        'incr', 'decr', 'gauge', 'set', 'timing', 'timer', 'pipeline',
     ])
     def test_passthrough_methods(self, method, stats_config):
         lc = LazyClient(**stats_config)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27-nameko{2.9, 2.10, 2.11, 2.12, latest},
-    {py35, py36, py37}-nameko{2.6, 2.7, 2.8, 2.9, 2.10, 2.11, 2.12, latest, next}
+    {py35, py36, py37}-nameko{2.7, 2.8, 2.9, 2.10, 2.11, 2.12, latest, next}
 
 skipsdist = True
 
@@ -10,9 +10,8 @@ whitelist_externals = make
 usedevelop = true
 extras = dev
 deps =
-    nameko{2.6,2.7}: pytest<3.3.0
-    nameko{2.6,2.7,2.8}: eventlet<0.22.0
-    nameko2.6: nameko~=2.6.0
+    nameko{2.7}: pytest<3.3.0
+    nameko{2.7,2.8}: eventlet<0.22.0
     nameko2.7: nameko~=2.7.0
     nameko2.8: nameko~=2.8.0
     nameko2.9: nameko~=2.9.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27-nameko{2.9, 2.10, 2.11, 2.12, latest},
-    {py35, py36, py37}-nameko{2.7, 2.8, 2.9, 2.10, 2.11, 2.12, latest, next}
+    {py35, py36, py37, py38}-nameko{2.7, 2.8, 2.9, 2.10, 2.11, 2.12, latest, next}
 
 skipsdist = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,13 +12,13 @@ extras = dev
 deps =
     nameko{2.6,2.7}: pytest<3.3.0
     nameko{2.6,2.7,2.8}: eventlet<0.22.0
-    nameko2.6: nameko~=2.6
-    nameko2.7: nameko~=2.7
-    nameko2.8: nameko~=2.8
-    nameko2.9: nameko~=2.9
-    nameko2.10: nameko~=2.10
-    nameko2.11: nameko~=2.11
-    nameko2.12: nameko~=2.12
+    nameko2.6: nameko~=2.6.0
+    nameko2.7: nameko~=2.7.0
+    nameko2.8: nameko~=2.8.0
+    nameko2.9: nameko~=2.9.0
+    nameko2.10: nameko~=2.10.0
+    nameko2.11: nameko~=2.11.0
+    nameko2.12: nameko~=2.12.0
 
 commands =
     make test


### PR DESCRIPTION
Changes:
- Add support for pipeline when disabled
- Fix test requirement pinning
- Drop support for the oldest Nameko (2.6)
- Add tests for Python 3.8