### PR TITLE
Fix attr name none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ nameko-statsd versions, where semantic versioning is used:
 Backwards-compatible changes increment the minor version number only.
 
 
+Version 0.1.3
+-------------
+* Prevent timer decorator and tests using worker_factory from failing
+
 Version 0.1.2
 -------------
 * Only install enum backport when needed

--- a/nameko_statsd/statsd_dep.py
+++ b/nameko_statsd/statsd_dep.py
@@ -138,6 +138,12 @@ class StatsD(DependencyProvider):
 
             @wraps(method)
             def wrapper(svc, *args, **kwargs):
+                # self.attr_name starts as None, then is set to the name of
+                # the attribute when bind is called. Until then, the decorator
+                # does nothing
+                if self.attr_name is None:
+                    return method(svc, *args, **kwargs)
+
                 dependency = getattr(svc, self.attr_name)
 
                 if dependency.enabled:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ description = 'StatsD dependency for nameko services.'
 
 setup(
     name='nameko-statsd',
-    version='0.1.2',
+    version='0.1.3',
     description=description,
     long_description=description,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
Tests that use `worker_factory` don't end up setting `attr_name`. This is because `bind` makes a clone of the dependency and doesn't alter the original.

This change makes the decorator a passthrough in those situations.